### PR TITLE
Update base.dm to stop burning cultist faces

### DIFF
--- a/code/modules/core_implant/cruciform/rituals/base.dm
+++ b/code/modules/core_implant/cruciform/rituals/base.dm
@@ -40,7 +40,7 @@
 
 /datum/ritual/cruciform/base/soul_hunger/perform(mob/living/carbon/human/H, obj/item/implant/core_implant/C)
 	H.nutrition += 50
-	H.adjustFireLoss(5)
+	H.adjustToxLoss(10)
 	return TRUE
 
 /datum/ritual/cruciform/base/glow_book


### PR DESCRIPTION
Changes the fire damage from the Soul Hunger litany back to the toxin damage used previously
This makes it so soul hunger can be healed by Cahors again as well and prevents church followers from having a litany render their face unrecognizable.

