### PR TITLE
Soteria Malpractice Fixes

### DIFF
--- a/code/modules/research/designs/weapon.dm
+++ b/code/modules/research/designs/weapon.dm
@@ -164,6 +164,24 @@
 	name_category = "ammunition"
 	category = "Ammo"
 
+/datum/design/research/item/ammo/pistol/empty
+	name = "Pistol Magazine 9mm (Empty)"
+	desc = "An empty magazine for pistols, chambered for 9mm"
+	build_path = /obj/item/ammo_magazine/pistol_35/empty
+	materials = list(MATERIAL_STEEL = 3)
+
+/datum/design/research/item/ammo/pistol
+	name = "Pistol Magazine 9mm"
+	desc = "A magazine for pistols, chambered for 9mm"
+	build_path = /obj/item/ammo_magazine/pistol_35
+	materials = list(MATERIAL_STEEL = 8)
+
+/datum/design/research/item/ammo/pistol/rubber
+	name = "Pistol Magazine 9mm (Rubber)"
+	desc = "A magazine for pistols, chambered for 9mm rubber"
+	build_path = /obj/item/ammo_magazine/pistol_35/rubber
+	materials = list(MATERIAL_STEEL = 6, MATERIAL_PLASTIC = 3)
+
 /datum/design/research/item/ammo/smg_mag
 	name = "SMG Magazine 9mm (Empty) "
 	desc = "A magazine for 9mm, used in smgs."

--- a/code/modules/research/nodes/combat.dm
+++ b/code/modules/research/nodes/combat.dm
@@ -12,7 +12,8 @@
 	cost = 0
 
 	unlocks_designs = list(/datum/design/research/item/clothing/security,
-							/datum/design/research/item/weapon/clarissa)
+							/datum/design/research/item/weapon/clarissa,
+							/datum/design/research/item/ammo/pistol/empty)
 
 // TO ADD: synth flashes?
 /datum/technology/basic_nonlethal
@@ -29,7 +30,8 @@
 	cost = 375
 
 	unlocks_designs = list(/datum/design/research/item/flash,
-						   /datum/design/research/item/weapon/weapon_upgrade/auto_eject_no_removal)
+						   /datum/design/research/item/weapon/weapon_upgrade/auto_eject_no_removal,
+						   /datum/design/research/item/ammo/pistol/rubber)
 
 
 
@@ -152,6 +154,7 @@
 	cost = 1500
 
 	unlocks_designs = list(/datum/design/research/item/weapon/large_grenade,
+							/datum/design/research/item/ammo/pistol,
 							/datum/design/research/item/ammo/smg_mag,
 							/datum/design/research/item/ammo/pistol_laser,
 							/datum/design/research/item/ammo/magum_laser,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	About The Pull Request
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Port of my Sojourn edit.

Adds 9mm pistol magazines compatible with the SI HG "Malpractice" low-power pistol to the Protolathe, allowing Soteria to use the weapon and experiment with ballistic designs in the same way as their C20r.
Specifically, this adds empty pistol magazines available by default, rubber magazines after researching basic non-lethal technology, and standard magazines after researching basic lethal weapons.

This makes the Malpractice consistent with the C20r in availability with empty, basic, and rubber smg ammo designs being available in the protolathe, and hopefully encourages early-game use of the often-forgotten Soteria knock-off pistol among Soteria personnel for defense and experimenting with the ballistic mod combinations available to research.
	
<hr>
</details>

## Changelog
:cl: Shirumic
add: Adds 9mm Pistol magazines compatible with the SI HG "Malpractice" low-power pistol to the Protolathe, bringing it's accessibility in-line with the C20r and hopefully encourages early-game use of the oft-forgotten Soteria knock-off pistol among Soteria personnel for personal defense and experimenting with the ballistic mod combinations available to research in R&D.
/:cl:
